### PR TITLE
impose scalar context on do/eval/require

### DIFF
--- a/lib/File/Slurper.pm
+++ b/lib/File/Slurper.pm
@@ -29,7 +29,7 @@ sub read_binary {
 
 use constant {
 	CRLF_DEFAULT => $^O eq 'MSWin32',
-	HAS_UTF8_STRICT => do { local $@; eval { require PerlIO::utf8_strict } },
+	HAS_UTF8_STRICT => scalar do { local $@; eval { require PerlIO::utf8_strict } },
 };
 
 sub _text_layers {


### PR DESCRIPTION
Without it, when the do/eval/require for HAS_UTF8_STRICT fails it returns an empty list, which gives us:

```
Odd number of elements in anonymous hash at .../File/Slurper.pm line 32.
```

Scalar context makes it return undef.
