### PR TITLE
Slurper.pm: add size restriction to read_binary

### DIFF
--- a/lib/File/Slurper.pm
+++ b/lib/File/Slurper.pm
@@ -13,11 +13,13 @@ our @EXPORT_OK = qw/read_binary read_text read_lines write_binary write_text rea
 
 sub read_binary {
 	my $filename = shift;
+	my $size = shift;
 
 	# This logic is a bit ugly, but gives a significant speed boost
 	# because slurpy readline is not optimized for non-buffered usage
 	open my $fh, '<:unix', $filename or croak "Couldn't open $filename: $!";
-	if (my $size = -s $fh) {
+	$size = -s $fh unless defined $size;
+	if ($size) {
 		my $buf;
 		my ($pos, $read) = 0;
 		do {
@@ -116,9 +118,10 @@ This module provides functions for fast and correct slurping and spewing. All fu
 
 Reads file C<$filename> into a scalar and decodes it from C<$encoding> (which defaults to UTF-8). If C<$crlf> is true, crlf translation is performed. The default for this argument is off. The special value C<'auto'> will set it to a platform specific default value.
 
-=func read_binary($filename)
+=func read_binary($filename, [$size])
 
 Reads file C<$filename> into a scalar without any decoding or transformation.
+When C<$size> is given, read only <$size> bytes.
 
 =func read_lines($filename, $encoding, $crlf, $skip_chomp)
 

--- a/t/10-basics.t
+++ b/t/10-basics.t
@@ -13,6 +13,12 @@ my $content = do { local $/; open my $fh, '<:raw', $0; <$fh> };
 is(read_text($0), $content, 'read_file() works');
 is(read_binary($0), $content, 'read_binary() works');
 
+if(-e "/dev/urandom")
+{
+    my $rand = read_binary("/dev/urandom", 16);
+    is(length $rand, 16, "read_binary(\$device, \$size) works");
+}
+
 my @content = split /(?<=\n)/, $content;
 
 is_deeply([ read_lines($0, 'utf-8', 0, 1) ], \@content, 'read_lines returns the right thing (no chomp)');


### PR DESCRIPTION
Binary files might or might not need to be read completely. If just a
header needs to be probed to make a decision or a kernel device needs to
be read, limiting the bytes to read is a good idea.

Signed-off-by: Jens Rehsack <sno@netbsd.org>